### PR TITLE
Add TS bar offset option

### DIFF
--- a/src/GUI/UIQuickMenuPopUp.cs
+++ b/src/GUI/UIQuickMenuPopUp.cs
@@ -28,6 +28,10 @@ namespace YetAnotherToolbar
         private UISlider verticalOffsetSlider;
         private UITextField verticalOffsetValueTextField;
 
+        private UILabel tsBarOffsetLabel;
+        private UISlider tsBarOffsetSlider;
+        private UITextField tsBarOffsetValueTextField;
+
         private UILabel backgroundLabel;
         private UIDropDown backgroundDropdown;
 
@@ -47,7 +51,7 @@ namespace YetAnotherToolbar
             name = "YetAnotherToolbar_UIQuickMenuPopUp";
             atlas = SamsamTS.UIUtils.GetAtlas("Ingame");
             backgroundSprite = "GenericPanelWhite";
-            size = new Vector2(460, 460);
+            size = new Vector2(460, 500);
             instance = this;
 
             UILabel title = AddUIComponent<UILabel>();
@@ -227,11 +231,39 @@ namespace YetAnotherToolbar
                 YetAnotherToolbar.instance.UpdatePanelPosition();
             };
 
+            tsBarOffsetLabel = AddUIComponent<UILabel>();
+            tsBarOffsetLabel.text = Translations.Translate("YAT_QM_TSO");
+            tsBarOffsetLabel.textScale = 0.8f;
+            tsBarOffsetLabel.textColor = new Color32(0, 0, 0, 255);
+            tsBarOffsetLabel.relativePosition = new Vector3(title.relativePosition.x, verticalOffsetLabel.relativePosition.y + verticalOffsetLabel.height + 30);
+
+            tsBarOffsetSlider = SamsamTS.UIUtils.CreateSlider(this, Settings.tsBarOffset, -1500.0f, 1500f, 10.0f);
+            tsBarOffsetSlider.relativePosition = new Vector3(tsBarOffsetLabel.relativePosition.x, tsBarOffsetLabel.relativePosition.y + tsBarOffsetLabel.height + 5);
+            tsBarOffsetSlider.eventValueChanged += (c, p) =>
+            {
+                if (tsBarOffsetSlider.value == Settings.tsBarOffset) return;
+                tsBarOffsetValueTextField.text = $"{tsBarOffsetSlider.value}";
+            };
+
+            tsBarOffsetValueTextField = SamsamTS.UIUtils.CreateTextField(this);
+            tsBarOffsetValueTextField.text = $"{Settings.tsBarOffset}";
+            tsBarOffsetValueTextField.width = 70;
+            tsBarOffsetValueTextField.relativePosition = new Vector3(tsBarOffsetSlider.relativePosition.x + tsBarOffsetSlider.width + 15, tsBarOffsetSlider.relativePosition.y - 10);
+            tsBarOffsetValueTextField.eventTextChanged += (c, p) =>
+            {
+                if (!int.TryParse(tsBarOffsetValueTextField.text, out int newValue)) return;
+                if (newValue < -1500 || newValue > 1500) return; // reasonable range
+                Settings.tsBarOffset = newValue;
+                XMLUtils.SaveSettings();
+                tsBarOffsetSlider.value = newValue;
+                YetAnotherToolbar.instance.UpdateTSBarOffset();
+            };
+
             backgroundLabel = AddUIComponent<UILabel>();
             backgroundLabel.text = Translations.Translate("YAT_QM_BAC");
             backgroundLabel.textScale = 0.8f;
             backgroundLabel.textColor = new Color32(0, 0, 0, 255);
-            backgroundLabel.relativePosition = new Vector3(title.relativePosition.x, verticalOffsetLabel.relativePosition.y + verticalOffsetLabel.height + 45);
+            backgroundLabel.relativePosition = new Vector3(title.relativePosition.x, tsBarOffsetLabel.relativePosition.y + tsBarOffsetLabel.height + 45);
 
             backgroundDropdown = SamsamTS.UIUtils.CreateDropDown(this);
             backgroundDropdown.normalBgSprite = "TextFieldPanelHovered";

--- a/src/ModSettings.cs
+++ b/src/ModSettings.cs
@@ -16,6 +16,7 @@ namespace YetAnotherToolbar
         internal static int numOfCols = 7;
         internal static int verticalOffset = 0;
         internal static int horizontalOffset = 0;
+        internal static int tsBarOffset = 0;
         internal static bool expanded = true;
         internal static bool hideMainButton = false;
         internal static bool disableUpdateNotice = false;
@@ -55,6 +56,9 @@ namespace YetAnotherToolbar
 
         [XmlElement("horizontalOffset")]
         public int HorizontalOffset { get => Settings.horizontalOffset; set => Settings.horizontalOffset = value; }
+
+        [XmlElement("tsBarOffset")]
+        public int TSBarOffset { get => Settings.tsBarOffset; set => Settings.tsBarOffset = value; }
 
         [XmlElement("expanded")]
         public bool Expanded { get => Settings.expanded; set => Settings.expanded = value; }

--- a/src/Translations/en.xml
+++ b/src/Translations/en.xml
@@ -19,6 +19,7 @@
     <Translation ID="YAT_QM_SCL" String="Panel UI scale:" />
     <Translation ID="YAT_QM_HOR" String="Horizontal position offset:" />
     <Translation ID="YAT_QM_VER" String="Vertical position offset:" />
+    <Translation ID="YAT_QM_TSO" String="TS Bar offset:" />
     <Translation ID="YAT_QM_BAC" String="Panel background:" />
     <Translation ID="YAT_QM_DRK" String="Dark" />
     <Translation ID="YAT_QM_LGH" String="Light" />

--- a/src/YetAnotherToolbar.cs
+++ b/src/YetAnotherToolbar.cs
@@ -25,6 +25,9 @@ namespace YetAnotherToolbar
         public bool hideMenuFlag = false;
         private Vector2 lastMenuPosition;
 
+        private static UITabstrip mainTS;
+        private static float originalTSPosX;
+
         private static UISlicedSprite thumbnailBar;
         private static UISlicedSprite tsBar;
         private static UIPanel infoPanel;
@@ -41,6 +44,7 @@ namespace YetAnotherToolbar
                 {
                     tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
                     thumbnailBar = UIView.Find<UISlicedSprite>("ThumbnailBar");
+                    mainTS = UIView.Find<UITabstrip>("MainToolstrip");
                     tsBar = UIView.Find<UISlicedSprite>("TSBar");
                     infoPanel = UIView.Find<UIPanel>("InfoPanel");
                     pauseOutline = GameObject.Find("PauseOutline")?.GetComponent<UIComponent>();
@@ -60,6 +64,8 @@ namespace YetAnotherToolbar
                         bool result = DrawPloppablePanelPatch.ApplyPatch(Patcher.harmonyInstance);
                         if (result) Debugging.Message($"Found enabled mod: ploppablerico. Yet Another Toolbar scale patch applied");
                     }
+
+                    originalTSPosX = mainTS.relativePosition.x;
 
                     originalScreenSize = UIView.GetAView().GetScreenResolution();
                     //UIMultiStateButton advisorButton = view.FindUIComponent<UIMultiStateButton>("AdvisorButton");
@@ -102,6 +108,7 @@ namespace YetAnotherToolbar
             UpdateThumbnailBarBackground();
             UpdateTSBarBackground();
             UpdateInfoPanelBackground();
+            UpdateTSBarOffset();
 
             UITabContainer gtsContainer;
             foreach (UIComponent toolPanel in tsContainer.components)
@@ -312,6 +319,11 @@ namespace YetAnotherToolbar
                 tsContainer.relativePosition = new Vector2(x, y + (104f * (1 - scale)));
             }
 
+        }
+
+        public void UpdateTSBarOffset()
+        {
+            mainTS.relativePosition = new Vector3(originalTSPosX + Settings.tsBarOffset, mainTS.relativePosition.y);
         }
 
         private void UpdateLayout(int numOfRows, int numCols)


### PR DESCRIPTION
Add an option to adjust the offset of the toolstrip. 
![yatpr_](https://user-images.githubusercontent.com/44744452/177029343-4cd521be-5458-4d4a-a23b-5d8b39459a16.gif)

Find It's 'center the main toolbar' can affect it. Is there any way to resolve it there?